### PR TITLE
Removes caches and temporary C files used to build the libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN <<eot
 bin/rails webpacker:compile
 rm -rf node_modules tmp/cache spec app/javascript .github .git
 rm .browserslistrc babel.config.js package.json postcss.config.js yarn.lock .rspec docker-compose.yml Makefile openapi.yaml
+rm -rf vendor/bundle/ruby/3.0.0/cache/*.gem
+find vendor/bundle/ruby/3.0.0/gems -name "*.c" -delete
+find vendor/bundle/ruby/3.0.0/gems -name "*.o" -delete
 eot
 
 FROM ruby:3.0.2-slim AS production


### PR DESCRIPTION
close shuntagami/rails_postgres#3

before and after

<img width="1266" alt="screenshot" src="https://user-images.githubusercontent.com/69618840/147736163-f88f48dd-2f54-4bd6-b95f-ba0e17132150.png">

```bash
❯ docker images | grep shuntagami/rails_postgres
shuntagami/rails_postgres                    46e36e6       54274dc845f8   3 hours ago     462MB
shuntagami/rails_postgres                    dcd47d7        f00a07525eda   3 hours ago     532MB
```